### PR TITLE
portage 2.2.0_alpha190 requires masters attribute to be set

### DIFF
--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -1,0 +1,1 @@
+masters = gentoo


### PR DESCRIPTION
Otherwise emerge always writes:
!!! Repository 'unity-gentoo' is missing masters attribute in '/var/lib/layman/unity-gentoo/metadata/layout.conf'
!!! Set 'masters = gentoo' in this file for future compatibility

Best,
Bela
