### PR TITLE
unity-gtk-module will fail to build with glib-2.36 or older due to a missing macro

### DIFF
--- a/unity-base/unity-gtk-module/unity-gtk-module-0.0.0_p0_p01-r3.ebuild
+++ b/unity-base/unity-gtk-module/unity-gtk-module-0.0.0_p0_p01-r3.ebuild
@@ -23,6 +23,7 @@ RESTRICT="mirror"
 
 RDEPEND="dev-libs/libdbusmenu:=[gtk]"
 DEPEND="${RDEPEND}
+	>=dev-libs/glib-2.38
 	x11-libs/libX11
 	x11-libs/gtk+:2
 	x11-libs/gtk+:3

--- a/unity-base/unity-gtk-module/unity-gtk-module-0.0.0a_p0_p01.ebuild
+++ b/unity-base/unity-gtk-module/unity-gtk-module-0.0.0a_p0_p01.ebuild
@@ -23,6 +23,7 @@ RESTRICT="mirror"
 
 RDEPEND="dev-libs/libdbusmenu:=[gtk]"
 DEPEND="${RDEPEND}
+	>=dev-libs/glib-2.38
 	x11-libs/libX11
 	x11-libs/gtk+:2
 	x11-libs/gtk+:3


### PR DESCRIPTION
The missing macro is G_MENU_ATTRIBUTE_ICON in gmenumodel.h
