### PR TITLE
Create oxide-qt-1.17.9-remove-_FORTIFY_SOURCE-warning.patch

### DIFF
--- a/net-libs/oxide-qt/files/oxide-qt-1.17.9-remove-_FORTIFY_SOURCE-warning.patch
+++ b/net-libs/oxide-qt/files/oxide-qt-1.17.9-remove-_FORTIFY_SOURCE-warning.patch
@@ -1,0 +1,27 @@
+diff -urN oxide-qt-1.17.9/build/common.gypi oxide-qt-1.17.9-patched/build/common.gypi
+--- oxide-qt-1.17.9/build/common.gypi	2016-06-29 06:51:46.000000000 +0930
++++ oxide-qt-1.17.9-patched/build/common.gypi	2016-08-12 18:42:12.914458033 +0930
+@@ -3494,23 +3494,6 @@
+               'ALLOCATOR_SHIM'
+             ],
+           }],
+-          # _FORTIFY_SOURCE isn't really supported by Clang now, see
+-          # http://llvm.org/bugs/show_bug.cgi?id=16821.
+-          # It seems to work fine with Ubuntu 12 headers though, so use it
+-          # in official builds.
+-          ['os_posix==1 and (asan!=1 and msan!=1 and tsan!=1 and lsan!=1 and ubsan!=1) and (OS!="linux" or clang!=1 or buildtype=="Official")', {
+-            'target_conditions': [
+-              ['chromium_code==1', {
+-                # Non-chromium code is not guaranteed to compile cleanly
+-                # with _FORTIFY_SOURCE. Also, fortified build may fail
+-                # when optimizations are disabled, so only do that for Release
+-                # build.
+-                'defines': [
+-                  '_FORTIFY_SOURCE=2',
+-                ],
+-              }],
+-            ],
+-          }],
+           ['OS=="linux" or OS=="android"', {
+             'target_conditions': [
+               ['_toolset=="target"', {


### PR DESCRIPTION
Patches needed for testing new ebuild.
Part 2 of 3