### PR TITLE
Make gtest a mandatory DEPEND

### DIFF
--- a/app-emulation/anbox/anbox-9999.2018.07.19-r4.ebuild
+++ b/app-emulation/anbox/anbox-9999.2018.07.19-r4.ebuild
@@ -65,13 +65,13 @@ DEPEND="${RDEPEND}
 	sys-apps/dbus
 	sys-libs/libcap
 	sys-apps/systemd[nat]
+	dev-cpp/gtest
 	playstore? ( app-arch/lzip
 			app-arch/tar
 			app-arch/unzip
 			net-misc/curl
 			sys-fs/squashfs-tools )
-	test? ( dev-cpp/gmock
-		dev-cpp/gtest )"
+	test? ( dev-cpp/gmock )"
 
 CONFIG_CHECK="
 	~ANDROID_BINDER_IPC


### PR DESCRIPTION
The build fails without gtest installed