### PR TITLE
Update gtk+-3.24.33_p_p1_p02-r1.ebuild

### DIFF
--- a/x11-libs/gtk+/gtk+-3.24.33_p_p1_p02-r1.ebuild
+++ b/x11-libs/gtk+/gtk+-3.24.33_p_p1_p02-r1.ebuild
@@ -39,7 +39,7 @@ COMMON_DEPEND="
 	media-libs/fontconfig[${MULTILIB_USEDEP}]
 	>=media-libs/libepoxy-1.0[X(+)?,${MULTILIB_USEDEP}]
 	>=net-libs/rest-0.7[${MULTILIB_USEDEP}]
-	>=x11-libs/cairo-1.14[aqua?,glib,svg,X?,${MULTILIB_USEDEP}]
+	>=x11-libs/cairo-1.14[aqua?,glib,X?,${MULTILIB_USEDEP}]
 	>=x11-libs/gdk-pixbuf-2.30:2[introspection?,${MULTILIB_USEDEP}]
 	>=x11-libs/pango-1.37.3[introspection?,${MULTILIB_USEDEP}]
 	x11-misc/shared-mime-info


### PR DESCRIPTION
Removed svg flag for x11-libs/cairo